### PR TITLE
feat/import default

### DIFF
--- a/lib/addImport.test.js
+++ b/lib/addImport.test.js
@@ -68,8 +68,8 @@ readFileSync('xxx');
 import { join } from 'path';
 import { readFileSync } from 'fs';
 
-readFileSync('a');
-join('a');
+join('a', 'b');
+readFileSync('xxx');
     `.trimLeft(),
     );
   });

--- a/lib/addImport.test.js
+++ b/lib/addImport.test.js
@@ -98,4 +98,27 @@ join('a');
     `.trimLeft(),
     );
   });
+
+  it('import default only', () => {
+    expect(
+      addImports(
+        `
+import childProcess from 'child_process';
+
+path.join('a');
+    `.trimLeft(),
+        {
+          fs: ['readFileSync'],
+          path: ['join', 'dirname'],
+        },
+      ),
+    ).toEqual(
+      `
+import childProcess from 'child_process';
+import { join } from 'path';
+
+path.join('a');
+    `.trimLeft(),
+    );
+  });
 });

--- a/lib/addImports.js
+++ b/lib/addImports.js
@@ -29,14 +29,14 @@ function buildSpecifiers(specifiers) {
     if (local === imported) return local;
     else return `${imported} as ${local}`;
   });
-  let defaultSpecifierCode = '';
+  const buildSpecifiersCode = [];
   if (defaultSpecifier) {
-    defaultSpecifierCode = `${defaultSpecifier.local}, `;
+    buildSpecifiersCode.push(`${defaultSpecifier.local}`);
   }
-  return [
-    defaultSpecifierCode,
-    specifiersCode.length ? `{ ${specifiersCode.join(', ')} }` : '',
-  ].join('');
+  if (specifiersCode.length) {
+    buildSpecifiersCode.push(`{ ${specifiersCode.join(', ')} }`);
+  }
+  return buildSpecifiersCode.join(', ');
 }
 
 function isESM(code) {


### PR DESCRIPTION
Should remove extra comma when only import default.

```js
import someModule, from 'some-module';
                 ^
SyntaxError: Unexpected token ,
```

example

```js
import assert from 'assert';

assert(1 === 1);
```

will be transformed to

```js
import assert,  from 'assert';

assert(1 === 1);
```